### PR TITLE
Add basic wifi support

### DIFF
--- a/gameros/airootfs/etc/systemd/system/multi-user.target.wants/NetworkManager.service
+++ b/gameros/airootfs/etc/systemd/system/multi-user.target.wants/NetworkManager.service
@@ -1,0 +1,1 @@
+/usr/lib/systemd/system/NetworkManager.service

--- a/gameros/packages.x86_64
+++ b/gameros/packages.x86_64
@@ -2,17 +2,16 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 amd-ucode
-# b43-fwcutter
+b43-fwcutter
 base
-# broadcom-wl
+broadcom-wl
 btrfs-progs
-dhcpcd
 diffutils
 dosfstools
 efibootmgr
 intel-ucode
-# ipw2100-fw
-# ipw2200-fw
+ipw2100-fw
+ipw2200-fw
 jq
 libnewt
 linux
@@ -20,11 +19,10 @@ linux-firmware
 mkinitcpio
 mkinitcpio-archiso
 nano
-netctl
+networkmanager
 openssh
 parted
 syslinux
 usbutils
-# wpa_supplicant
 wget
 zsh


### PR DESCRIPTION
This adds basic wifi support to the installer. If the system is not connected it will check if it can find wifi networks and list them to the user. After that the user will be asked to fill out the password. The BSSID will then be used to connect.

Now there still are a couple of problems with the way this is currently implemented:

- If an SSID contains a space, only the first word will be used in the name in the selection menu.
- nmcli somehow has a return code of 0 if the password is wrong.
- The list of wifi networks looks different the second time around for some reason. The tab which should be there is excluded. Maybe the array is not being cleared as expected.
- The amount of lines which should be reserved in whiptail is a bit strange. Not sure how to fix it, but the selection box doesn't quite have the size expected.
- frzr requires a small change to make sure the contents of ``/etc/NetworkManager/system-connections/`` is copied during installation, so there is a wifi connection upon first boot.

That's why this PR is still a draft at the moment. Feel free to add additional commits to it, as I'm not sure how much time I'll have in the upcoming couple of weeks. I just wanted to make sure this was out there and available for testing.