### PR TITLE
Add NetworkManager support during installation

### DIFF
--- a/gameros/airootfs/etc/systemd/system/dbus-org.freedesktop.nm-dispatcher.service
+++ b/gameros/airootfs/etc/systemd/system/dbus-org.freedesktop.nm-dispatcher.service
@@ -1,0 +1,1 @@
+/usr/lib/systemd/system/NetworkManager-dispatcher.service

--- a/gameros/airootfs/etc/systemd/system/multi-user.target.wants/NetworkManager.service
+++ b/gameros/airootfs/etc/systemd/system/multi-user.target.wants/NetworkManager.service
@@ -1,0 +1,1 @@
+/usr/lib/systemd/system/NetworkManager.service

--- a/gameros/airootfs/etc/systemd/system/multi-user.target.wants/iwd.service
+++ b/gameros/airootfs/etc/systemd/system/multi-user.target.wants/iwd.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/system/iwd.service

--- a/gameros/airootfs/etc/systemd/system/network-online.target.wants/NetworkManager-wait-online.service
+++ b/gameros/airootfs/etc/systemd/system/network-online.target.wants/NetworkManager-wait-online.service
@@ -1,0 +1,1 @@
+/usr/lib/systemd/system/NetworkManager-wait-online.service

--- a/gameros/airootfs/root/install.sh
+++ b/gameros/airootfs/root/install.sh
@@ -28,6 +28,15 @@ if ! frzr-bootstrap gamer; then
     exit 1
 fi
 
+# Post install steps for system configuration
+# Copy over all network configuration from the live session to the system
+MOUNT_PATH=/tmp/frzr_root
+if [ -d "/etc/NetworkManager/system-connections" ]; then
+    mkdir -p -m=700 ${MOUNT_PATH}/etc/NetworkManager/system-connections
+    cp  /etc/NetworkManager/system-connections/* \
+        ${MOUNT_PATH}/etc/NetworkManager/system-connections/.
+fi
+
 export SHOW_UI=1
 if ! frzr-deploy gamer-os/gamer-os:stable; then
     echo "Installation failed."

--- a/gameros/airootfs/root/install.sh
+++ b/gameros/airootfs/root/install.sh
@@ -6,10 +6,7 @@ if [ $EUID -ne 0 ]; then
     exit 1
 fi
 
-#### Wait for conenction or ask the user for configuration ####
-whiptail --infobox "Checking connection..." 10 50
-sleep 5
-
+#### Test conenction or ask the user for configuration ####
 while ! ( curl -Is https://gamer-os.github.io/ | head -1 | grep 200 > /dev/null ); do
     whiptail --yesno "No wired connection detected. Please connect this computer \
      to the internet by configuring a new network." 10 50 \

--- a/gameros/airootfs/root/install.sh
+++ b/gameros/airootfs/root/install.sh
@@ -20,7 +20,7 @@ while ! ( curl -Is https://gamer-os.github.io/ | head -1 | grep 200 > /dev/null 
          exit 1
     fi
 
-    nmtui
+    nmtui-connect
 done
 #######################################
 

--- a/gameros/airootfs/root/install.sh
+++ b/gameros/airootfs/root/install.sh
@@ -2,38 +2,38 @@
 
 
 if [ $EUID -ne 0 ]; then
-	echo "$(basename $0) must be run as root"
-	exit 1
+    echo "$(basename $0) must be run as root"
+    exit 1
 fi
 
-#### Internet connection detection ####
-dhcpcd --background
-
+#### Wait for conenction or ask the user for configuration ####
 whiptail --infobox "Checking connection..." 10 50
 sleep 5
 
 while ! ( curl -Is https://gamer-os.github.io/ | head -1 | grep 200 > /dev/null ); do
-	whiptail --yesno "No internet connection detected. Please connect this computer\
-	 to the internet with a wired connection, wait a few seconds, then retry." 10 50\
-	 --yes-button "Retry"\
-	 --no-button "Exit"
+    whiptail --yesno "No wired connection detected. Please connect this computer \
+     to the internet by configuring a new network." 10 50 \
+     --yes-button "Configure" \
+     --no-button "Exit"
 
-	if [ $? -ne 0 ]; then
-		 exit 1
-	fi
+    if [ $? -ne 0 ]; then
+         exit 1
+    fi
+
+    nmtui
 done
 #######################################
 
 if ! frzr-bootstrap gamer; then
-	exit
+    exit 1
 fi
 
 export SHOW_UI=1
 if ! frzr-deploy gamer-os/gamer-os:stable; then
-	echo "Installation failed."
-	exit
+    echo "Installation failed."
+    exit 1
 fi
 
 if (whiptail --yesno "Installation complete. Would you like to restart now?" 10 50); then
-	reboot
+    reboot
 fi

--- a/gameros/packages.x86_64
+++ b/gameros/packages.x86_64
@@ -29,3 +29,4 @@ usbutils
 wget
 zsh
 frzr
+networkmanager

--- a/gameros/packages.x86_64
+++ b/gameros/packages.x86_64
@@ -2,17 +2,17 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 amd-ucode
-# b43-fwcutter
+b43-fwcutter
 base
-# broadcom-wl
+broadcom-wl
 btrfs-progs
 dhcpcd
 diffutils
 dosfstools
 efibootmgr
 intel-ucode
-# ipw2100-fw
-# ipw2200-fw
+ipw2100-fw
+ipw2200-fw
 jq
 libnewt
 linux
@@ -25,7 +25,6 @@ openssh
 parted
 syslinux
 usbutils
-# wpa_supplicant
 wget
 zsh
 frzr


### PR DESCRIPTION
- Add `networkmanager` package to the iso
- Remove `iwd` service that could interfere with NM
- Add `NetworkManager` services to start at boot
- Ask the user for configuration of the network if it doesn't detect one during install.
- Add some common off-tree firmware and packages
- Minor fix: retab from tabs to spaces.

~~Note: changes to frzr post-install are needed for this to fully work in
the installed system (i.e. nm system connections need to be copied over)~~

Do the post-install steps into `install.sh` assuming `frzr-bootstrap` does not unmount the installed system under `/tmp/frzr_root`. This makes changes in `frzr` project uneccessary for this to work.

Fixes #29 