### PR TITLE
Add `frzr` package to the install media

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
+temp/
 output/
+gameros/extra_pkg/
 gameros/work/
+gameros/pacman.conf

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ On Arch the following packages will need to be installed:
 - grep
 - file
 - coreutils
+- pikaur
 
 To start building, use the following command:
 

--- a/build-iso.sh
+++ b/build-iso.sh
@@ -19,5 +19,28 @@ mkdir -p "${output_dir}"
 rm -rf "${temp_dir}"
 mkdir -p "${temp_dir}"
 
+# add AUR packages to the build
+AUR_PACKAGES=frzr
+
+# create repo directory if it doesn't exist yet
+LOCAL_REPO="${script_dir}/extra_pkg"
+mkdir -p ${LOCAL_REPO}
+
+PIKAUR_CMD="PKGDEST=/tmp/temp_repo pikaur --noconfirm -Sw ${AUR_PACKAGES}"
+PIKAUR_RUN=(bash -c "${PIKAUR_CMD}")
+if [ -n "${BUILD_USER}" ]; then
+	PIKAUR_RUN=(su "${BUILD_USER}" -c "${PIKAUR_CMD}")
+fi
+
+# build packages to the repo
+"${PIKAUR_RUN[@]}"
+
+# copy all built packages to the repo
+cp /tmp/temp_repo/* ${LOCAL_REPO}
+
+# Add the repo to the build
+repo-add ${LOCAL_REPO}/gameros.db.tar.gz ${LOCAL_REPO}/*.pkg.*
+sed "s|LOCAL_REPO|$LOCAL_REPO|g" $script_dir/pacman.conf.template > $script_dir/pacman.conf
+
 # make the container build the iso
 exec mkarchiso -v -w "${temp_dir}" -o "${output_dir}" "${script_dir}"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,21 @@
 #Dockerfile for building GamerOS
 #Based on Arch
 
-FROM archlinux:base
+FROM archlinux:base-devel
 MAINTAINER Wouter Wijsman
 
 #Install archiso
-RUN yes | pacman -Syuu grep file archiso lynx
+RUN yes | pacman -Syuu archiso lynx
+RUN pacman --noconfirm -S --needed git pyalpm python-commonmark
+RUN echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
+    useradd build -G wheel -m
+RUN su - build -c "git clone https://aur.archlinux.org/pikaur.git /tmp/pikaur" && \
+    su - build -c "cd /tmp/pikaur && makepkg -f" && \
+    pacman --noconfirm -U /tmp/pikaur/pikaur-*.pkg.tar.zst
+
+# Add a fake systemd-run script to workaround pikaur requirement.
+RUN echo -e "#!/bin/bash\nif [[ \"$1\" == \"--version\" ]]; then echo 'fake 244 version'; fi\nmkdir -p /var/cache/pikaur\n" >> /usr/bin/systemd-run && \
+    chmod +x /usr/bin/systemd-run
 
 #set working dir, you'll have to mount something yourself here
 WORKDIR /root/gameros

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,5 +20,10 @@ RUN echo -e "#!/bin/bash\nif [[ \"$1\" == \"--version\" ]]; then echo 'fake 244 
 #set working dir, you'll have to mount something yourself here
 WORKDIR /root/gameros
 
+# Build pikaur packages as the 'build' user
+ENV BUILD_USER "build"
+
+ENV GNUPGHOME  "/etc/pacman.d/gnupg"
+
 #Copy archiso files from this git repo
 ADD gameros /root/gameros

--- a/gameros/airootfs/root/install.sh
+++ b/gameros/airootfs/root/install.sh
@@ -24,14 +24,6 @@ while ! ( curl -Is https://gamer-os.github.io/ | head -1 | grep 200 > /dev/null 
 done
 #######################################
 
-#### Install frzr
-curl -L https://github.com/gamer-os/frzr/releases/download/0.7.0/frzr-0.7.0-1-any.pkg.tar.zst > frzr.pkg.tar.zst
-pacman --noconfirm -U frzr.pkg.tar.zst
-if [ $? -ne 0 ]; then
-	exit 1
-fi
-rm frzr.pkg.tar.zst
-
 if ! frzr-bootstrap gamer; then
 	exit
 fi

--- a/gameros/packages.x86_64
+++ b/gameros/packages.x86_64
@@ -28,3 +28,4 @@ usbutils
 # wpa_supplicant
 wget
 zsh
+frzr

--- a/gameros/pacman.conf.template
+++ b/gameros/pacman.conf.template
@@ -99,3 +99,7 @@ Include = /etc/pacman.d/mirrorlist
 #[custom]
 #SigLevel = Optional TrustAll
 #Server = file:///home/custompkgs
+
+[gameros]
+SigLevel = Optional TrustAll
+Server = file://LOCAL_REPO


### PR DESCRIPTION
As a byproduct this add the ability to build any AUR package into the install media.

- Add `pikaur` to the packages needed to build the image.
- Add a generic way to add packages built from the AUR. More packages can be added by changing the `AUR_PACKAGES` variable in `build-iso.sh`.
- Bugfix: Make docker container able to use pikaur.
- Add a custom repo to the build made from AUR packages. `pacman.conf` now is a template that the script needs to recreate.
- Add `frzr` to the list of packages