### PR TITLE
Dirty fix online check

### DIFF
--- a/chimeraos/airootfs/root/install.sh
+++ b/chimeraos/airootfs/root/install.sh
@@ -7,7 +7,7 @@ if [ $EUID -ne 0 ]; then
 fi
 
 #### Test conenction or ask the user for configuration ####
-while ! ( curl -Is https://chimeraos.github.io/ | head -1 | grep 200 > /dev/null ); do
+while ! ( curl -Is https://chimeraos.org/ | head -1 | grep 200 > /dev/null ); do
     whiptail --yesno "No wired connection detected. Please connect this computer \
      to the internet by configuring a new network." 10 50 \
      --yes-button "Configure" \


### PR DESCRIPTION
Since the change in the CNAME the installer can't check for online since
we are expecting code 200 and the site returns 301.

Fixing by changing the pointer for curl command.