### PR TITLE
Try to detect intel-nvidia optimus configuration

### DIFF
--- a/chimeraos/airootfs/root/install.sh
+++ b/chimeraos/airootfs/root/install.sh
@@ -47,7 +47,7 @@ INTEL_BUSID=$(lspci -nm -d 8086: | \
     sed 's/\./:/' )
 
 if [[ $INTEL_BUSID == ??:??:? && $NVIDIA_BUSID == ??:??:? ]] ; then
-    if (whiptail --yesno "Intel/Nvidia hybrid setup is detected. Would you like to use this configuration?"); then
+    if (whiptail --yesno "Intel/Nvidia hybrid graphics detected. Would you like to force use of Nvidia graphics?"); then
         echo "
 Section \"ServerLayout\"
     Identifier \"layout\"

--- a/chimeraos/airootfs/root/install.sh
+++ b/chimeraos/airootfs/root/install.sh
@@ -25,13 +25,53 @@ if ! frzr-bootstrap gamer; then
     exit 1
 fi
 
-# Post install steps for system configuration
+#### Post install steps for system configuration
 # Copy over all network configuration from the live session to the system
 MOUNT_PATH=/tmp/frzr_root
 if [ -d "/etc/NetworkManager/system-connections" ]; then
     mkdir -p -m=700 ${MOUNT_PATH}/etc/NetworkManager/system-connections
     cp  /etc/NetworkManager/system-connections/* \
         ${MOUNT_PATH}/etc/NetworkManager/system-connections/.
+fi
+
+# Detect hybrid intel-nvidia setups
+NVIDIA_BUSID=$(lspci -nm -d 10de: | \
+    awk '{print $1 " " $2 " " $3}' | \
+    grep -e 300 -e 302 | \
+    awk '{print $1}' | \
+    sed 's/\./:/' )
+INTEL_BUSID=$(lspci -nm -d 8086: | \
+    awk '{print $1 " " $2 " " $3}' | \
+    grep -e 300 -e 302 | \
+    awk '{print $1}' | \
+    sed 's/\./:/' )
+
+if [[ $INTEL_BUSID == ??:??:? && $NVIDIA_BUSID == ??:??:? ]] ; then
+    if (whiptail --yesno "Intel/Nvidia hybrid setup is detected. Would you like to use this configuration?"); then
+        echo "
+Section \"ServerLayout\"
+    Identifier \"layout\"
+    Screen 0 \"iGPU\"
+    Option \"AllowNVIDIAGPUScreens\"
+EndSection
+
+Section \"Screen\"
+    Identifier \"iGPU\"
+    Device \"iGPU\"
+EndSection
+
+Section \"Device\"
+    Identifier \"iGPU\"
+    Driver \"modesetting\"
+    BusID \"${INTEL_BUSID}\"
+EndSection
+
+Section \"Device\"
+    Identifier \"dGPU\"
+    Driver \"nvidia\"
+    BusID \"${NVIDIA_BUSID}\"
+EndSection" > ${MOUNT_PATH}/etc/X11/xorg.conf.d/10-nvidia-prime.conf
+    fi
 fi
 
 export SHOW_UI=1


### PR DESCRIPTION
After we install the system try to detect an intel VGA/3D controller
and a Nvidia one. If we found that we ask the user if it likes to use
it. Answering NO will just do nothing. Answering YES will set up a
layout configuration using modesetting driver as primary GPU and nvidia
driver as secondary driver. Then the user can use nvidia-prime (using prime-run) or set
the aproppriate variables to run games offloading frames on the
dedicated GPU.

This setup Nvidia claims to be also supported with AMD iGPUs and both
intel and amdgpu Xorg drivers. Those configurations/combinations should
be tested but maybe just using modesetting is the safest bet (and
detection of AMD iGPU should be added).

Note that AMD configurations just need PRIME=1 to be set to offload
frames and current X11 autodetection should work on those setups.