### PR TITLE
Add rz608-fix

### DIFF
--- a/build-iso.sh
+++ b/build-iso.sh
@@ -28,6 +28,7 @@ AUR_PACKAGES="\
     r8152-dkms \
     rtl8812au-dkms-git \
     rtl8814au-dkms-git \
+    rz608-fix-git \
 "
 
 # create repo directory if it doesn't exist yet


### PR DESCRIPTION
Sync up with current v35 image hardware support.