### PR TITLE
Remove hybrid graphics detection

### DIFF
--- a/chimeraos/airootfs/root/install.sh
+++ b/chimeraos/airootfs/root/install.sh
@@ -38,46 +38,6 @@ if [ -d ${SYS_CONN_DIR} ] && [ -n "$(ls -A ${SYS_CONN_DIR})" ]; then
         ${MOUNT_PATH}${SYS_CONN_DIR}/.
 fi
 
-# Detect hybrid intel-nvidia setups
-NVIDIA_BUSID=$(lspci -nm -d 10de: | \
-    awk '{print $1 " " $2 " " $3}' | \
-    grep -e 300 -e 302 | \
-    awk '{print $1}' | \
-    sed 's/\./:/' )
-INTEL_BUSID=$(lspci -nm -d 8086: | \
-    awk '{print $1 " " $2 " " $3}' | \
-    grep -e 300 -e 302 | \
-    awk '{print $1}' | \
-    sed 's/\./:/' )
-
-if [[ $INTEL_BUSID == ??:??:? && $NVIDIA_BUSID == ??:??:? ]] ; then
-    if (whiptail --yesno "Intel/Nvidia hybrid graphics detected. Would you like to force use of Nvidia graphics?"); then
-        echo "
-Section \"ServerLayout\"
-    Identifier \"layout\"
-    Screen 0 \"iGPU\"
-    Option \"AllowNVIDIAGPUScreens\"
-EndSection
-
-Section \"Screen\"
-    Identifier \"iGPU\"
-    Device \"iGPU\"
-EndSection
-
-Section \"Device\"
-    Identifier \"iGPU\"
-    Driver \"modesetting\"
-    BusID \"${INTEL_BUSID}\"
-EndSection
-
-Section \"Device\"
-    Identifier \"dGPU\"
-    Driver \"nvidia\"
-    BusID \"${NVIDIA_BUSID}\"
-EndSection" > ${MOUNT_PATH}/etc/X11/xorg.conf.d/10-nvidia-prime.conf
-    fi
-fi
-
 export SHOW_UI=1
 frzr-deploy chimeraos/chimeraos:stable
 RESULT=$?


### PR DESCRIPTION
It is really not useful. Hybrids are hardware dependent and when they work, the X11 config is not needed anyway.