### PR TITLE
Fix pxe booting

### DIFF
--- a/chimeraos/airootfs/etc/mkinitcpio.conf
+++ b/chimeraos/airootfs/etc/mkinitcpio.conf
@@ -52,7 +52,7 @@ FILES=()
 #
 ##   NOTE: If you have /usr on a separate partition, you MUST include the
 #    usr, fsck and shutdown hooks.
-HOOKS=(base udev memdisk archiso archiso_loop_mnt archiso_kms block filesystems keyboard microcode)
+HOOKS=(base udev memdisk archiso archiso_loop_mnt archiso_kms archiso_pxe_common archiso_pxe_nbd archiso_pxe_http archiso_pxe_nfs block filesystems keyboard microcode)
 
 # COMPRESSION
 # Use this to compress the initramfs image. By default, gzip compression

--- a/chimeraos/packages.x86_64
+++ b/chimeraos/packages.x86_64
@@ -31,3 +31,5 @@ wget
 zsh
 frzr
 networkmanager
+mkinitcpio-nfs-utils
+nbd

--- a/chimeraos/syslinux/archiso_pxe-linux.cfg
+++ b/chimeraos/syslinux/archiso_pxe-linux.cfg
@@ -7,9 +7,9 @@ Boot the ChimeraOS installer.
 It allows you to install ChimeraOS.
 ENDTEXT
 MENU LABEL Arch Linux install medium (x86_64, NBD)
-LINUX /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux
-INITRD /%INSTALL_DIR%/boot/intel-ucode.img,/%INSTALL_DIR%/boot/amd-ucode.img,/%INSTALL_DIR%/boot/x86_64/initramfs-linux.img
-APPEND archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% archiso_nbd_srv=${pxeserver} checksum verify
+LINUX ::/%INSTALL_DIR%/boot/x86_64/vmlinuz-linux-chimeraos
+INITRD ::/%INSTALL_DIR%/boot/x86_64/initramfs-linux-chimeraos.img
+APPEND archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% archiso_nbd_srv=${pxeserver} checksum
 SYSAPPEND 3
 
 LABEL arch64_nfs
@@ -18,9 +18,9 @@ Boot the ChimeraOS installer.
 It allows you to install ChimeraOS.
 ENDTEXT
 MENU LABEL Arch Linux install medium (x86_64, NFS)
-LINUX /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux
-INITRD /%INSTALL_DIR%/boot/intel-ucode.img,/%INSTALL_DIR%/boot/amd-ucode.img,/%INSTALL_DIR%/boot/x86_64/initramfs-linux.img
-APPEND archisobasedir=%INSTALL_DIR% archiso_nfs_srv=${pxeserver}:/run/archiso/bootmnt checksum verify
+LINUX ::/%INSTALL_DIR%/boot/x86_64/vmlinuz-linux-chimeraos
+INITRD ::/%INSTALL_DIR%/boot/x86_64/initramfs-linux-chimeraos.img
+APPEND archisobasedir=%INSTALL_DIR% archiso_nfs_srv=${pxeserver}:/run/archiso/bootmnt checksum
 SYSAPPEND 3
 
 LABEL arch64_http
@@ -29,7 +29,7 @@ Boot the ChimeraOS installer.
 It allows you to install ChimeraOS.
 ENDTEXT
 MENU LABEL Arch Linux install medium (x86_64, HTTP)
-LINUX /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux
-INITRD /%INSTALL_DIR%/boot/intel-ucode.img,/%INSTALL_DIR%/boot/amd-ucode.img,/%INSTALL_DIR%/boot/x86_64/initramfs-linux.img
-APPEND archisobasedir=%INSTALL_DIR% archiso_http_srv=http://${pxeserver}/ checksum verify
+LINUX ::/%INSTALL_DIR%/boot/x86_64/vmlinuz-linux-chimeraos
+INITRD ::/%INSTALL_DIR%/boot/x86_64/initramfs-linux-chimeraos.img
+APPEND archisobasedir=%INSTALL_DIR% archiso_http_srv=http://${pxeserver}/ checksum
 SYSAPPEND 3


### PR DESCRIPTION
PXE booting was broken due to missing hooks and packages.
The `archiso_pxe-linux.cfg` changes where not mandatory since `install.sh` enforce EFI and archiso don't support PXE over EFI.
But i needed the hooks and packages additions since you can boot an arch system using tools like [IPXE](https://ipxe.org/).